### PR TITLE
Nested translation key changes

### DIFF
--- a/src/main/java/dev/qixils/quasicord/locale/TranslationProvider.java
+++ b/src/main/java/dev/qixils/quasicord/locale/TranslationProvider.java
@@ -154,7 +154,7 @@ public final class TranslationProvider {
 	 * Loads translations from the configured namespace.
 	 */
 	@SuppressWarnings("unchecked")
-	public void loadTranslations() throws IOException {
+	private void loadTranslations() throws IOException {
 		Yaml yaml = new Yaml();
 
 		// each language yaml file

--- a/src/test/java/dev/qixils/quasicord/test/MockBot.java
+++ b/src/test/java/dev/qixils/quasicord/test/MockBot.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 
 public class MockBot extends Quasicord {
     public MockBot() throws LoginException, IOException, InterruptedException {
-        super("mockbot", Collections.singletonList(Locale.ENGLISH), Paths.get(".").toAbsolutePath(), null, null);
+        super("mockbot", Locale.ENGLISH, Paths.get(".").toAbsolutePath(), null, null);
     }
 
     @Override


### PR DESCRIPTION
- allTranslations is only accessed in the context of a known locale
    - transposed? (e.g. top level is locale) to match input format
    - but this is the shape of discord's translations. Keep.

- loadTranslations only loads from res://
    - and only called in TranslationProvider()
    -> can assume initial state is clean

- Java doesn't have nice unions for a Node = Map<String, Node|String> ish thing
    - translations are never written to at runtime
    -> yaml files are flattened in loadTranslations()

- Supported locales is 1:1 with $locale.yaml
    -> removed locales array param
    -> discovered during loadTranslations

-> translation shape issues throw an exception