### PR TITLE
Fix exception when parsing dates with no times

### DIFF
--- a/src/main/java/dev/qixils/quasicord/converter/impl/ZonedDateTimeConverter.java
+++ b/src/main/java/dev/qixils/quasicord/converter/impl/ZonedDateTimeConverter.java
@@ -94,8 +94,10 @@ public class ZonedDateTimeConverter implements Converter<String, ZonedDateTime> 
 		// get time
 		Matcher timeMatcher = TIME_PATTERN.matcher(input);
 		if (timeMatcher.find()) {
-			hour = Integer.parseInt(timeMatcher.group("hour"));
-			minute = Integer.parseInt(timeMatcher.group("minute"));
+			if (timeMatcher.group("hour") != null)
+				hour = Integer.parseInt(timeMatcher.group("hour"));
+			if (timeMatcher.group("minute") != null)
+				minute = Integer.parseInt(timeMatcher.group("minute"));
 			if (timeMatcher.group("second") != null)
 				second = Integer.parseInt(timeMatcher.group("second"));
 			if (timeMatcher.group("nanos") != null)


### PR DESCRIPTION
Otherwise, `parseInt` throws because it is passed `null`.

Alternatively, we *could* throw a `UserError` if you want to just reject dates without times as invalid, instead of whatever `parseInt` throws that we don't catch.