### PR TITLE
Annotate token in config as `@Required`

### DIFF
--- a/src/main/java/dev/qixils/quasicord/QuasicordConfig.java
+++ b/src/main/java/dev/qixils/quasicord/QuasicordConfig.java
@@ -7,10 +7,11 @@
 package dev.qixils.quasicord;
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+import org.spongepowered.configurate.objectmapping.meta.Required;
 
 @ConfigSerializable
 record QuasicordConfig(
-		String token,
+		@Required String token,
 		Environment environment
 ) {
 	public QuasicordConfig {


### PR DESCRIPTION
Results in the proper "invalid config.yml" error, instead of just passing null all the way down to JDA.